### PR TITLE
HEN-121 - Add InterfaceInputManager, IInterfaceComponent

### DIFF
--- a/HenHen.Framework.Tests/Input/UI/InterfaceInputManagerTests.cs
+++ b/HenHen.Framework.Tests/Input/UI/InterfaceInputManagerTests.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Affectionate Dove <contact@affectionatedove.com>.
+// Licensed under the Affectionate Dove Limited Code Viewing License.
+// See the LICENSE file in the repository root for full license text.
+
+using HenHen.Framework.Graphics2d;
+using HenHen.Framework.Input.UI;
+using HenHen.Framework.Screens;
+using NUnit.Framework;
+
+namespace HenHen.Framework.Tests.Input.UI
+{
+    [Timeout(1000)]
+    public class InterfaceInputManagerTests
+    {
+        private InterfaceInputManager<TestAction> interfaceInputManager;
+        private Screen screen;
+        private TestComponent component1;
+        private TestComponent component2;
+        private TestComponent component3Nested;
+        private TestComponent component4Nested;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var screenStack = new ScreenStack();
+            screen = new Screen();
+            component1 = new TestComponent(1);
+            component2 = new TestComponent(2);
+            var componentContainer = new Container();
+            componentContainer.AddChild(component3Nested = new TestComponent(3));
+            componentContainer.AddChild(component4Nested = new TestComponent(4));
+            interfaceInputManager = new(screenStack);
+            screen.AddChild(component1);
+            screen.AddChild(component2);
+            screen.AddChild(componentContainer);
+            screenStack.Push(screen);
+        }
+
+        [Test]
+        public void HandleNoComponentsTest()
+        {
+            component1.AcceptsFocus = false;
+            component2.AcceptsFocus = false;
+            component3Nested.AcceptsFocus = false;
+            component4Nested.AcceptsFocus = false;
+            interfaceInputManager.FocusNextComponent();
+            Assert.IsNull(interfaceInputManager.CurrentComponent);
+        }
+
+        [Test]
+        public void GetNextComponentTest()
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                interfaceInputManager.FocusNextComponent();
+                Assert.AreEqual(component1, interfaceInputManager.CurrentComponent);
+                interfaceInputManager.FocusNextComponent();
+                Assert.AreEqual(component2, interfaceInputManager.CurrentComponent);
+                interfaceInputManager.FocusNextComponent();
+                Assert.AreEqual(component3Nested, interfaceInputManager.CurrentComponent);
+                interfaceInputManager.FocusNextComponent();
+                Assert.AreEqual(component4Nested, interfaceInputManager.CurrentComponent);
+            }
+        }
+
+        [Test]
+        public void GetNextComponentWithDisabledComponentTest()
+        {
+            component2.AcceptsFocus = false;
+            for (var i = 0; i < 3; i++)
+            {
+                interfaceInputManager.FocusNextComponent();
+                Assert.AreEqual(component1, interfaceInputManager.CurrentComponent);
+                interfaceInputManager.FocusNextComponent();
+                Assert.AreSame(component3Nested, interfaceInputManager.CurrentComponent);
+                interfaceInputManager.FocusNextComponent();
+                Assert.AreEqual(component4Nested, interfaceInputManager.CurrentComponent);
+            }
+        }
+
+        [Test]
+        public void GetNextComponentWithLayoutChangeTest()
+        {
+            interfaceInputManager.FocusNextComponent();
+            Assert.AreEqual(component1, interfaceInputManager.CurrentComponent);
+            screen.RemoveChild(component2);
+            Assert.DoesNotThrow(() => interfaceInputManager.FocusNextComponent());
+        }
+
+        private class TestComponent : Drawable, IInterfaceComponent<TestAction>
+        {
+            private readonly int id;
+
+            public bool AcceptsFocus { get; set; } = true;
+
+            public TestComponent(int id) => this.id = id;
+
+            public override string ToString() => id.ToString();
+
+            public void OnFocus()
+            {
+            }
+
+            public void OnFocusLost()
+            {
+            }
+
+            public bool OnActionPressed(TestAction action) => throw new System.NotImplementedException();
+
+            public void OnActionReleased(TestAction action) => throw new System.NotImplementedException();
+        }
+    }
+}

--- a/HenHen.Framework.Tests/Input/UI/InterfaceInputManagerTests.cs
+++ b/HenHen.Framework.Tests/Input/UI/InterfaceInputManagerTests.cs
@@ -108,6 +108,23 @@ namespace HenHen.Framework.Tests.Input.UI
             Assert.AreSame(component1, interfaceInputManager.CurrentlyFocusedComponent);
         }
 
+        [Test]
+        public void UnfocusTest()
+        {
+            interfaceInputManager.FocusNextComponent();
+            Assert.AreSame(component1, interfaceInputManager.CurrentlyFocusedComponent);
+            interfaceInputManager.FocusNextComponent();
+            Assert.AreSame(component2, interfaceInputManager.CurrentlyFocusedComponent);
+            interfaceInputManager.FocusNextComponent();
+            Assert.AreSame(component3Nested, interfaceInputManager.CurrentlyFocusedComponent);
+
+            interfaceInputManager.Unfocus();
+            Assert.IsNull(interfaceInputManager.CurrentlyFocusedComponent);
+
+            interfaceInputManager.FocusNextComponent();
+            Assert.AreSame(component1, interfaceInputManager.CurrentlyFocusedComponent);
+        }
+
         private class TestComponent : Drawable, IInterfaceComponent<TestAction>
         {
             private readonly int id;

--- a/HenHen.Framework.Tests/Input/UI/InterfaceInputManagerTests.cs
+++ b/HenHen.Framework.Tests/Input/UI/InterfaceInputManagerTests.cs
@@ -44,7 +44,7 @@ namespace HenHen.Framework.Tests.Input.UI
             component3Nested.AcceptsFocus = false;
             component4Nested.AcceptsFocus = false;
             interfaceInputManager.FocusNextComponent();
-            Assert.IsNull(interfaceInputManager.CurrentComponent);
+            Assert.IsNull(interfaceInputManager.CurrentlyFocusedComponent);
         }
 
         [Test]
@@ -53,13 +53,13 @@ namespace HenHen.Framework.Tests.Input.UI
             for (var i = 0; i < 3; i++)
             {
                 interfaceInputManager.FocusNextComponent();
-                Assert.AreEqual(component1, interfaceInputManager.CurrentComponent);
+                Assert.AreEqual(component1, interfaceInputManager.CurrentlyFocusedComponent);
                 interfaceInputManager.FocusNextComponent();
-                Assert.AreEqual(component2, interfaceInputManager.CurrentComponent);
+                Assert.AreEqual(component2, interfaceInputManager.CurrentlyFocusedComponent);
                 interfaceInputManager.FocusNextComponent();
-                Assert.AreEqual(component3Nested, interfaceInputManager.CurrentComponent);
+                Assert.AreEqual(component3Nested, interfaceInputManager.CurrentlyFocusedComponent);
                 interfaceInputManager.FocusNextComponent();
-                Assert.AreEqual(component4Nested, interfaceInputManager.CurrentComponent);
+                Assert.AreEqual(component4Nested, interfaceInputManager.CurrentlyFocusedComponent);
             }
         }
 
@@ -70,11 +70,11 @@ namespace HenHen.Framework.Tests.Input.UI
             for (var i = 0; i < 3; i++)
             {
                 interfaceInputManager.FocusNextComponent();
-                Assert.AreEqual(component1, interfaceInputManager.CurrentComponent);
+                Assert.AreEqual(component1, interfaceInputManager.CurrentlyFocusedComponent);
                 interfaceInputManager.FocusNextComponent();
-                Assert.AreSame(component3Nested, interfaceInputManager.CurrentComponent);
+                Assert.AreSame(component3Nested, interfaceInputManager.CurrentlyFocusedComponent);
                 interfaceInputManager.FocusNextComponent();
-                Assert.AreEqual(component4Nested, interfaceInputManager.CurrentComponent);
+                Assert.AreEqual(component4Nested, interfaceInputManager.CurrentlyFocusedComponent);
             }
         }
 
@@ -82,9 +82,30 @@ namespace HenHen.Framework.Tests.Input.UI
         public void GetNextComponentWithLayoutChangeTest()
         {
             interfaceInputManager.FocusNextComponent();
-            Assert.AreEqual(component1, interfaceInputManager.CurrentComponent);
+            Assert.AreEqual(component1, interfaceInputManager.CurrentlyFocusedComponent);
             screen.RemoveChild(component2);
             Assert.DoesNotThrow(() => interfaceInputManager.FocusNextComponent());
+        }
+
+        [Test]
+        public void NextComponentActionTest()
+        {
+            var inputManager = new TestInputManager();
+            var inputActionHandler = new TestInputActionHandler(inputManager);
+            inputActionHandler.Propagator.Listeners.Add(interfaceInputManager);
+            interfaceInputManager.NextComponentAction = TestAction.Action1;
+
+            Assert.IsNull(interfaceInputManager.CurrentlyFocusedComponent);
+
+            inputManager.SimulateKeyPress(Framework.Input.KeyboardKey.KEY_A);
+            inputActionHandler.Update();
+            inputManager.Update(1);
+
+            inputManager.SimulateKeyRelease(Framework.Input.KeyboardKey.KEY_A);
+            inputActionHandler.Update();
+            inputManager.Update(1);
+
+            Assert.AreSame(component1, interfaceInputManager.CurrentlyFocusedComponent);
         }
 
         private class TestComponent : Drawable, IInterfaceComponent<TestAction>

--- a/HenHen.Framework.Tests/Input/UI/InterfaceInputManagerTests.cs
+++ b/HenHen.Framework.Tests/Input/UI/InterfaceInputManagerTests.cs
@@ -6,6 +6,7 @@ using HenHen.Framework.Graphics2d;
 using HenHen.Framework.Input.UI;
 using HenHen.Framework.Screens;
 using NUnit.Framework;
+using System;
 
 namespace HenHen.Framework.Tests.Input.UI
 {
@@ -123,6 +124,22 @@ namespace HenHen.Framework.Tests.Input.UI
 
             interfaceInputManager.FocusNextComponent();
             Assert.AreSame(component1, interfaceInputManager.CurrentlyFocusedComponent);
+        }
+
+        [Test]
+        public void FocusComponentTest()
+        {
+            interfaceInputManager.FocusComponent(component3Nested);
+            Assert.AreSame(component3Nested, interfaceInputManager.CurrentlyFocusedComponent);
+
+            interfaceInputManager.FocusNextComponent();
+            Assert.AreSame(component4Nested, interfaceInputManager.CurrentlyFocusedComponent);
+
+            interfaceInputManager.FocusComponent(component2);
+            Assert.AreSame(component2, interfaceInputManager.CurrentlyFocusedComponent);
+
+            var outsideComponent = new TestComponent(5);
+            Assert.Throws<InvalidOperationException>(() => interfaceInputManager.FocusComponent(outsideComponent));
         }
 
         private class TestComponent : Drawable, IInterfaceComponent<TestAction>

--- a/HenHen.Framework.Tests/Input/UI/InterfaceInputManagerTests.cs
+++ b/HenHen.Framework.Tests/Input/UI/InterfaceInputManagerTests.cs
@@ -156,6 +156,27 @@ namespace HenHen.Framework.Tests.Input.UI
             Assert.Throws<InvalidOperationException>(() => interfaceInputManager.FocusComponent(outsideComponent));
         }
 
+        [Test]
+        public void FocusFromComponentToNothingTest()
+        {
+            interfaceInputManager.FocusNextComponent();
+            AssertContains(component1, interfaceInputManager.FocusedComponents);
+
+            screen.Children.Clear();
+            interfaceInputManager.FocusNextComponent();
+            Assert.IsEmpty(interfaceInputManager.FocusedComponents);
+        }
+
+        [Test]
+        public void UnfocusOnScreenChange()
+        {
+            interfaceInputManager.FocusNextComponent();
+            Assert.IsNotEmpty(interfaceInputManager.FocusedComponents);
+
+            screen.Push(new Screen());
+            Assert.IsEmpty(interfaceInputManager.FocusedComponents);
+        }
+
         private static void AssertContains<T>(T expected, IEnumerable<T> actual) => Assert.IsTrue(actual.Contains(expected));
 
         private static void AssertContains<T>(IEnumerable<T> expected, IEnumerable<T> actual) => Assert.IsTrue(actual.Intersect(expected).Count() == actual.Count());

--- a/HenHen.Framework.VisualTests/Input/UI/InterfaceInputManagerTestScene.cs
+++ b/HenHen.Framework.VisualTests/Input/UI/InterfaceInputManagerTestScene.cs
@@ -52,9 +52,14 @@ namespace HenHen.Framework.VisualTests.Input.UI
             base.PreUpdate();
         }
 
-        private class TestFillFlowContainer : Container
+        private class TestFillFlowContainer : Container, IInterfaceComponent<TestAction>
         {
+            private readonly Rectangle background;
+            private readonly byte v;
+
             public FillFlowContainer FillFlowContainer { get; }
+
+            public bool AcceptsFocus => true;
 
             public TestFillFlowContainer(float brightness, int height, int buttonAmount)
             {
@@ -67,14 +72,22 @@ namespace HenHen.Framework.VisualTests.Input.UI
                     Spacing = 10
                 };
                 RelativeSizeAxes = Axes.X;
-                var v = (byte)(brightness * 255);
-                AddChild(new Rectangle { RelativeSizeAxes = Axes.Both, Color = new(v, v, v) });
+                v = (byte)(brightness * 255);
+                AddChild(background = new Rectangle { RelativeSizeAxes = Axes.Both, Color = new(v, v, v) });
                 AddChild(FillFlowContainer);
                 for (var i = 0; i < buttonAmount; i++)
                     FillFlowContainer.AddChild(new TestButton(i + 1, brightness - 0.1f));
             }
 
             public void AddChildToFlowContainer(Drawable drawable) => FillFlowContainer.AddChild(drawable);
+
+            public void OnFocus() => background.Color = new(v, v, 0);
+
+            public void OnFocusLost() => background.Color = new(v, v, v);
+
+            public bool OnActionPressed(TestAction action) => false;
+
+            public void OnActionReleased(TestAction action) => throw new System.NotImplementedException();
         }
 
         private class TestButton : Button<TestAction>

--- a/HenHen.Framework.VisualTests/Input/UI/InterfaceInputManagerTestScene.cs
+++ b/HenHen.Framework.VisualTests/Input/UI/InterfaceInputManagerTestScene.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Affectionate Dove <contact@affectionatedove.com>.
+// Licensed under the Affectionate Dove Limited Code Viewing License.
+// See the LICENSE file in the repository root for full license text.
+
+using HenHen.Framework.Graphics2d;
+using HenHen.Framework.Input;
+using HenHen.Framework.Input.UI;
+using HenHen.Framework.Screens;
+using HenHen.Framework.UI;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace HenHen.Framework.VisualTests.Input.UI
+{
+    public class InterfaceInputManagerTestScene : VisualTestScene
+    {
+        private readonly InterfaceInputManager<TestAction> interfaceInputManager;
+        private readonly TestInputActionHandler inputActionHandler;
+
+        public InterfaceInputManagerTestScene()
+        {
+            inputActionHandler = new TestInputActionHandler(Game.InputManager);
+            var screenStack = new ScreenStack
+            {
+                Size = new Vector2(500, 400),
+                Offset = new(100)
+            };
+            AddChild(screenStack);
+            var screen1 = new Screen();
+            screenStack.Push(screen1);
+            screen1.AddChild(new Rectangle { RelativeSizeAxes = Axes.Both, Color = new(100, 200, 50) });
+            var mainFillFlowContainer = new TestFillFlowContainer(0.6f, 400, 0);
+            screen1.AddChild(mainFillFlowContainer);
+            var header = new TestFillFlowContainer(0.5f, 70, 2);
+            mainFillFlowContainer.AddChildToFlowContainer(header);
+
+            var horizontalContainer = new TestFillFlowContainer(0.5f, 300, 0);
+            horizontalContainer.FillFlowContainer.Direction = Direction.Horizontal;
+            var leftContainer = new TestFillFlowContainer(0.4f, 1, 3) { RelativeSizeAxes = Axes.Y, Size = new(100, 1) };
+            var rightContainer = new TestFillFlowContainer(0.4f, 1, 3) { RelativeSizeAxes = Axes.Y, Size = new(100, 1) };
+            mainFillFlowContainer.AddChildToFlowContainer(horizontalContainer);
+            horizontalContainer.AddChildToFlowContainer(leftContainer);
+            horizontalContainer.AddChildToFlowContainer(rightContainer);
+
+            interfaceInputManager = new InterfaceInputManager<TestAction>(screenStack, TestAction.Next);
+            inputActionHandler.Propagator.Listeners.Add(interfaceInputManager);
+        }
+
+        protected override void PreUpdate()
+        {
+            inputActionHandler.Update();
+            base.PreUpdate();
+        }
+
+        private class TestFillFlowContainer : Container
+        {
+            public FillFlowContainer FillFlowContainer { get; }
+
+            public TestFillFlowContainer(float brightness, int height, int buttonAmount)
+            {
+                Size = new(1, height);
+                FillFlowContainer = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = Direction.Vertical,
+                    Padding = new() { Horizontal = 10, Vertical = 10 },
+                    Spacing = 10
+                };
+                RelativeSizeAxes = Axes.X;
+                var v = (byte)(brightness * 255);
+                AddChild(new Rectangle { RelativeSizeAxes = Axes.Both, Color = new(v, v, v) });
+                AddChild(FillFlowContainer);
+                for (var i = 0; i < buttonAmount; i++)
+                    FillFlowContainer.AddChild(new TestButton(i + 1, brightness - 0.1f));
+            }
+
+            public void AddChildToFlowContainer(Drawable drawable) => FillFlowContainer.AddChild(drawable);
+        }
+
+        private class TestButton : Button<TestAction>
+        {
+            private readonly byte v;
+
+            public TestButton(int id, float brightness)
+            {
+                v = (byte)(brightness * 255);
+                Color = new(v, v, v);
+                RelativeSizeAxes = Axes.X;
+                Size = new(1, 20);
+                Text = id.ToString();
+            }
+
+            public override void OnFocus() => Color = new(v, 255, 255);
+
+            public override void OnFocusLost() => Color = new(v, v, v);
+        }
+
+        private class TestInputActionHandler : InputActionHandler<TestAction>
+        {
+            public TestInputActionHandler(InputManager inputManager) : base(inputManager)
+            {
+            }
+
+            protected override Dictionary<TestAction, List<KeyboardKey>> CreateDefaultKeybindings() => new()
+            {
+                { TestAction.Up, new() { KeyboardKey.KEY_UP } },
+                { TestAction.Down, new() { KeyboardKey.KEY_DOWN } },
+                { TestAction.Left, new() { KeyboardKey.KEY_LEFT } },
+                { TestAction.Right, new() { KeyboardKey.KEY_RIGHT } },
+                { TestAction.Next, new() { KeyboardKey.KEY_TAB } },
+            };
+        }
+
+        private enum TestAction
+        {
+            Up,
+            Left,
+            Down,
+            Right,
+            Next
+        }
+    }
+}

--- a/HenHen.Framework.VisualTests/Input/UI/InterfaceInputManagerTestScene.cs
+++ b/HenHen.Framework.VisualTests/Input/UI/InterfaceInputManagerTestScene.cs
@@ -103,7 +103,7 @@ namespace HenHen.Framework.VisualTests.Input.UI
                 Text = id.ToString();
             }
 
-            public override void OnFocus() => Color = new(v, 255, 255);
+            public override void OnFocus() => Color = new(0, v, v);
 
             public override void OnFocusLost() => Color = new(v, v, v);
         }

--- a/HenHen.Framework.VisualTests/Input/UI/InterfaceInputManagerTestScene.cs
+++ b/HenHen.Framework.VisualTests/Input/UI/InterfaceInputManagerTestScene.cs
@@ -46,10 +46,10 @@ namespace HenHen.Framework.VisualTests.Input.UI
             inputActionHandler.Propagator.Listeners.Add(interfaceInputManager);
         }
 
-        protected override void PreUpdate()
+        protected override void OnUpdate()
         {
             inputActionHandler.Update();
-            base.PreUpdate();
+            base.OnUpdate();
         }
 
         private class TestFillFlowContainer : Container, IInterfaceComponent<TestAction>

--- a/HenHen.Framework.VisualTests/VisualTester.cs
+++ b/HenHen.Framework.VisualTests/VisualTester.cs
@@ -175,7 +175,7 @@ namespace HenHen.Framework.VisualTests
             }
         }
 
-        private class TestSceneButton : Button
+        private class TestSceneButton : Button<VisualTesterControls>
         {
             private static readonly ColorInfo highlightColor = new(100, 100, 100);
             private static readonly ColorInfo defaultColor = new(60, 60, 60);

--- a/HenHen.Framework/Input/InputPropagator.cs
+++ b/HenHen.Framework/Input/InputPropagator.cs
@@ -28,17 +28,18 @@ namespace HenHen.Framework.Input
                 triggeredListeners.Add(enumValue, null);
         }
 
-        public void OnActionPressed(TInputAction action)
+        public bool OnActionPressed(TInputAction action)
         {
             for (var i = Listeners.Count - 1; i >= 0; i--)
             {
                 if (Listeners[i].OnActionPressed(action))
                 {
                     triggeredListeners[action] = Listeners[i];
-                    return;
+                    return true;
                 }
             }
             triggeredListeners[action] = null;
+            return false;
         }
 
         public void OnActionReleased(TInputAction action)

--- a/HenHen.Framework/Input/UI/IInterfaceComponent.cs
+++ b/HenHen.Framework/Input/UI/IInterfaceComponent.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Affectionate Dove <contact@affectionatedove.com>.
+// Licensed under the Affectionate Dove Limited Code Viewing License.
+// See the LICENSE file in the repository root for full license text.
+
+namespace HenHen.Framework.Input.UI
+{
+    public interface IInterfaceComponent<TInputAction> : IInputListener<TInputAction>
+    {
+        bool AcceptsFocus { get; }
+
+        void OnFocus();
+
+        void OnFocusLost();
+    }
+}

--- a/HenHen.Framework/Input/UI/IInterfaceComponent.cs
+++ b/HenHen.Framework/Input/UI/IInterfaceComponent.cs
@@ -4,12 +4,24 @@
 
 namespace HenHen.Framework.Input.UI
 {
+    /// <summary>
+    ///     A component that can get focused for input.
+    /// </summary>
     public interface IInterfaceComponent<TInputAction> : IInputListener<TInputAction>
     {
+        /// <summary>
+        ///     Whether this component can be focused.
+        /// </summary>
         bool AcceptsFocus { get; }
 
+        /// <summary>
+        ///     Called when this component gets focused.
+        /// </summary>
         void OnFocus();
 
+        /// <summary>
+        ///     Called when this component loses focus.
+        /// </summary>
         void OnFocusLost();
     }
 }

--- a/HenHen.Framework/Input/UI/InterfaceInputManager.cs
+++ b/HenHen.Framework/Input/UI/InterfaceInputManager.cs
@@ -14,7 +14,7 @@ namespace HenHen.Framework.Input.UI
     ///     (<seealso cref="IInterfaceComponent{TInputAction}"/>)
     ///     focus and input.
     /// </summary>
-    public class InterfaceInputManager<TInputAction> : IInputListener<TInputAction> where TInputAction : struct, System.Enum
+    public class InterfaceInputManager<TInputAction> : IInputListener<TInputAction> where TInputAction : struct, Enum
     {
         private readonly Stack<ContainerAndEnumerator> stack = new();
         private readonly InputPropagator<TInputAction> inputPropagator;
@@ -195,7 +195,7 @@ namespace HenHen.Framework.Input.UI
                 if (enumerator.MoveNext())
                     return HandleDrawable(enumerator.Current);
             }
-            catch (System.InvalidOperationException)
+            catch (InvalidOperationException)
             {
             }
 

--- a/HenHen.Framework/Input/UI/InterfaceInputManager.cs
+++ b/HenHen.Framework/Input/UI/InterfaceInputManager.cs
@@ -82,15 +82,26 @@ namespace HenHen.Framework.Input.UI
 
                 if (HandleEnumerator())
                 {
-                    inputPropagator?.Listeners.Remove(previouslyFocusedComponent);
-                    previouslyFocusedComponent?.OnFocusLost();
-
-                    inputPropagator?.Listeners.Add(CurrentlyFocusedComponent);
-                    CurrentlyFocusedComponent.OnFocus();
-
+                    UnfocusComponent(previouslyFocusedComponent);
+                    FocusComponent(CurrentlyFocusedComponent);
                     return;
                 }
             };
+        }
+
+        /// <summary>
+        ///     Removes focus from <see cref="CurrentlyFocusedComponent"/>.
+        /// </summary>
+        /// <remarks>
+        ///     The <see cref="FocusNextComponent"/> function will begin
+        ///     seeking from the beginning the next time it's called.
+        /// </remarks>
+        public void Unfocus()
+        {
+            stack.Clear();
+            UnfocusComponent(CurrentlyFocusedComponent);
+            CurrentlyFocusedComponent = null;
+            inputPropagator?.Listeners.RemoveAll(listener => listener is not NextComponentActionListener);
         }
 
         /// <summary>
@@ -117,6 +128,18 @@ namespace HenHen.Framework.Input.UI
         ///     or calls the <see cref="FocusNextComponent"/> function.
         /// </summary>
         public void OnActionReleased(TInputAction action) => inputPropagator.OnActionReleased(action);
+
+        private void UnfocusComponent(IInterfaceComponent<TInputAction> previouslyFocusedComponent)
+        {
+            inputPropagator?.Listeners.Remove(previouslyFocusedComponent);
+            previouslyFocusedComponent?.OnFocusLost();
+        }
+
+        private void FocusComponent(IInterfaceComponent<TInputAction> component)
+        {
+            inputPropagator?.Listeners.Add(component);
+            component.OnFocus();
+        }
 
         /// <summary>
         ///     Advances the <see cref="IEnumerator{Drawable}"/>

--- a/HenHen.Framework/Input/UI/InterfaceInputManager.cs
+++ b/HenHen.Framework/Input/UI/InterfaceInputManager.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) Affectionate Dove <contact@affectionatedove.com>.
+// Licensed under the Affectionate Dove Limited Code Viewing License.
+// See the LICENSE file in the repository root for full license text.
+
+using HenHen.Framework.Graphics2d;
+using HenHen.Framework.Screens;
+using System.Collections.Generic;
+
+namespace HenHen.Framework.Input.UI
+{
+    public class InterfaceInputManager<TInputAction> : IInputListener<TInputAction> where TInputAction : System.Enum
+    {
+        private readonly Stack<ContainerAndEnumerator> stack = new();
+        private readonly InputPropagator<TInputAction> inputPropagator;
+
+        public ScreenStack ScreenStack { get; }
+        public IInterfaceComponent<TInputAction> CurrentComponent { get; private set; }
+        public TInputAction NextComponentAction { get; set; }
+
+        public InterfaceInputManager(ScreenStack screenStack) => ScreenStack = screenStack;
+
+        public InterfaceInputManager(ScreenStack screenStack, TInputAction nextComponentAction) : this(screenStack)
+        {
+            NextComponentAction = nextComponentAction;
+            inputPropagator = new();
+            inputPropagator.Listeners.Add(new NextComponentActionListener(this));
+        }
+
+        public void FocusNextComponent()
+        {
+            var previouslyFocusedComponent = CurrentComponent;
+
+            var restartCount = 0;
+            while (true)
+            {
+                if (RestartStackIfNeeded())
+                    restartCount++;
+                if (restartCount == 2)
+                    return;
+
+                var enumerator = stack.Peek().Enumerator;
+                if (HandleEnumerator(enumerator))
+                {
+                    inputPropagator?.Listeners.Remove(previouslyFocusedComponent);
+                    previouslyFocusedComponent?.OnFocusLost();
+
+                    inputPropagator?.Listeners.Add(CurrentComponent);
+                    CurrentComponent.OnFocus();
+
+                    return;
+                }
+            };
+        }
+
+        public bool OnActionPressed(TInputAction action) => inputPropagator.OnActionPressed(action);
+
+        public void OnActionReleased(TInputAction action) => inputPropagator.OnActionReleased(action);
+
+        private bool HandleEnumerator(IEnumerator<Drawable> enumerator)
+        {
+            try
+            {
+                if (enumerator.MoveNext())
+                {
+                    if (HandleDrawable(enumerator.Current))
+                        return true;
+                }
+                else
+                    stack.Pop();
+            }
+            catch (System.InvalidOperationException)
+            {
+                stack.Pop();
+            }
+            return false;
+        }
+
+        private bool RestartStackIfNeeded()
+        {
+            if (stack.Count == 0)
+            {
+                stack.Push(new(ScreenStack.CurrentScreen));
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool HandleDrawable(Drawable drawable)
+        {
+            if (drawable is Container container)
+                stack.Push(new(container));
+            if (drawable is IInterfaceComponent<TInputAction> component)
+            {
+                if (!component.AcceptsFocus)
+                    return false;
+
+                CurrentComponent = component;
+                return true;
+            }
+            return false;
+        }
+
+        private struct ContainerAndEnumerator
+        {
+            public Container Container;
+            public IEnumerator<Drawable> Enumerator;
+
+            public ContainerAndEnumerator(Container container)
+            {
+                Container = container;
+                Enumerator = container.Children.GetEnumerator();
+            }
+        }
+
+        private class NextComponentActionListener : IInputListener<TInputAction>
+        {
+            private readonly InterfaceInputManager<TInputAction> interfaceInputManager;
+
+            public NextComponentActionListener(InterfaceInputManager<TInputAction> interfaceInputManager) => this.interfaceInputManager = interfaceInputManager;
+
+            public bool OnActionPressed(TInputAction action) => true;
+
+            public void OnActionReleased(TInputAction action) => interfaceInputManager.FocusNextComponent();
+        }
+    }
+}

--- a/HenHen.Framework/Screens/ScreenStack.cs
+++ b/HenHen.Framework/Screens/ScreenStack.cs
@@ -14,6 +14,10 @@ namespace HenHen.Framework.Screens
     {
         private readonly List<Screen> screens = new();
 
+        public event Action<Screen> ScreenPushed;
+
+        public event Action<Screen> ScreenPopped;
+
         public Screen CurrentScreen => screens.Count == 0 ? null : screens[^1];
 
         public IEnumerable<Screen> Children => screens;
@@ -26,6 +30,7 @@ namespace HenHen.Framework.Screens
             screen.Parent = this;
             screens.Add(screen);
             RewireEventObserving(prev);
+            ScreenPushed?.Invoke(screen);
         }
 
         public void Pop()
@@ -36,6 +41,7 @@ namespace HenHen.Framework.Screens
             CurrentScreen.Parent = null;
             screens.Remove(CurrentScreen);
             RewireEventObserving(prev);
+            ScreenPopped?.Invoke(prev);
         }
 
         protected override void PostUpdate()

--- a/HenHen.Framework/UI/Button.cs
+++ b/HenHen.Framework/UI/Button.cs
@@ -3,12 +3,13 @@
 // See the LICENSE file in the repository root for full license text.
 
 using HenHen.Framework.Graphics2d;
+using HenHen.Framework.Input.UI;
 using System;
 using System.Numerics;
 
 namespace HenHen.Framework.UI
 {
-    public class Button : Container, IHasColor
+    public class Button<TInputAction> : Container, IHasColor, IInterfaceComponent<TInputAction>
     {
         private readonly Rectangle background;
         private readonly SpriteText spriteText;
@@ -16,6 +17,8 @@ namespace HenHen.Framework.UI
         public ColorInfo Color { get => background.Color; set => background.Color = value; }
         public string Text { get => spriteText.Text; set => spriteText.Text = value; }
         public Action Action { get; set; }
+
+        public virtual bool AcceptsFocus => true;
 
         public Button()
         {
@@ -30,6 +33,20 @@ namespace HenHen.Framework.UI
                 RelativeSizeAxes = Axes.Both,
                 AlignMiddle = true
             });
+        }
+
+        public virtual void OnFocus()
+        {
+        }
+
+        public virtual void OnFocusLost()
+        {
+        }
+
+        public virtual bool OnActionPressed(TInputAction action) => false;
+
+        public virtual void OnActionReleased(TInputAction action)
+        {
         }
     }
 }


### PR DESCRIPTION
- [x] XMLDocs for classes and public members.
- [x] On screen change, focus should automatically be recalculated.
  - [x] Consider focus changing from a component to nothing.
- [x] ~~On each `CurrentlyFocusedComponent.get`, validate whether it's still reachable through the `Drawable` tree.~~ - An implementation of invalidating layout should provide a good way to do this in the future.
- [x] Ability to Unfocus everything
- [x] A `Container` that is a `IInterfaceComponent` should have focus simultaneously with its children.
- [x] Ability to focus an interface component. The `InterfaceInputManager` should search through the `Drawable` tree to give focus. If the component cannot be found, an exception should be thrown.